### PR TITLE
Modified section edit such that it works with Greebo

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -138,7 +138,11 @@ class syntax_plugin_tabbox extends DokuWiki_Syntax_Plugin {
 
         // write the header
         $R->doc .= '<div class="tabboxtab" id="tab_'.$tabid.'">'.DOKU_LF;
-        $R->doc .= DOKU_LF . '<h' . $level . ' class="hl ' . $R->startSectionEdit($pos, 'section', $name) . '" id="' . $tabid . '">';
+        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+            $R->doc .= DOKU_LF . '<h' . $level . ' class="hl '.  $R->startSectionEdit($pos, array('target' => 'section', 'name' => $name)) . '" id="' . $tabid . '">';
+            } else {
+            $R->doc .= DOKU_LF . '<h' . $level . ' class="hl '.  $R->startSectionEdit($pos, 'section', $name)  . '" id="' . $tabid . '">';
+            }
         $R->doc .= $R->_xmlEntities($name);
         $R->doc .= "</h$level>" . DOKU_LF;
 

--- a/syntax.php
+++ b/syntax.php
@@ -138,11 +138,12 @@ class syntax_plugin_tabbox extends DokuWiki_Syntax_Plugin {
 
         // write the header
         $R->doc .= '<div class="tabboxtab" id="tab_'.$tabid.'">'.DOKU_LF;
-        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+        if (defined('SEC_EDIT_PATTERN')) { 
+            // for DokuWiki Greebo and more recent versions
             $R->doc .= DOKU_LF . '<h' . $level . ' class="hl '.  $R->startSectionEdit($pos, array('target' => 'section', 'name' => $name)) . '" id="' . $tabid . '">';
-            } else {
+        } else {
             $R->doc .= DOKU_LF . '<h' . $level . ' class="hl '.  $R->startSectionEdit($pos, 'section', $name)  . '" id="' . $tabid . '">';
-            }
+        }
         $R->doc .= $R->_xmlEntities($name);
         $R->doc .= "</h$level>" . DOKU_LF;
 


### PR DESCRIPTION
Section edit was re-factored in the Dokuwiki release “Greebo”, see https://www.dokuwiki.org/devel:section_editor. After updating Dokuwiki to "Greebo", the error "startSectionEdit: $data "section" is NOT an array!" appeared on top of each page that contains tabboxes. I modified the syntax part of the tabbox plugin such that it now works with "Greebo" and is still backward compatible.