### PR TITLE
Fix: Unable to click on "Edit" button of Tab

### DIFF
--- a/style.less
+++ b/style.less
@@ -27,6 +27,7 @@
         margin-top: 0;
         top: 0px;
         right: 0;
+        width: auto;
     }
 
 }


### PR DESCRIPTION
Fix an issue which makes impossible to click on "Edit" button of tab.
Before the fix:

https://github.com/user-attachments/assets/1fb58516-c6b3-43c6-982c-3d6c9c4c1aeb

After the fix:

https://github.com/user-attachments/assets/1978aabf-13ff-4050-9dbe-e6fc546c8972

It was happening because for some reason the edit button was taking 100% of the screen, overlaping the tabbox, as can be seen below:

<img width="814" alt="image" src="https://github.com/user-attachments/assets/01e81506-a885-4c78-930a-854ccf7b09c1" />

With the fix it only takes the space it needs without overlapping the tabs:

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/7f9eecef-8ecd-40fc-9e2d-24639540cefa" />
